### PR TITLE
1.1.18

### DIFF
--- a/dsa_helpers/__init__.py
+++ b/dsa_helpers/__init__.py
@@ -3,7 +3,7 @@ from .imread import imread
 from .imwrite import imwrite
 
 # Version of the dsa-helpers package
-__version__ = "1.1.18dev0"
+__version__ = "1.1.18"
 
 # To avoid slow downs, do not allow from dsa_helpers import * to import anything.
 __all__ = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 keywords = ["dsa", "girder", "girder_client"]
-version = "v1.1.18dev0"
+version = "v1.1.18"
 
 [project.optional-dependencies]
 opencv = ["opencv-python"]


### PR DESCRIPTION
Opencv now an optional dependency, can specify headless or non-headless version to install as optional.